### PR TITLE
Update categories.js

### DIFF
--- a/dataGrabber/categories.js
+++ b/dataGrabber/categories.js
@@ -2,7 +2,7 @@ export const categories = [
     {
         dataName: 'R',
         displayName: 'R',
-        fantraxCellId: 6
+        fantraxCellId: 5 // Was 6, but fantrax has hits in 6, this should fix the leaderboard.
     },
     {
         dataName: 'HR',


### PR DESCRIPTION
Leaderboard was displaying hit totals in the runs cat, most likely due to fantrax having runs come before hits in it's stupid thing. And is it stupid. Who puts runs first? Idiots. That's who.